### PR TITLE
Fixed defaults not being overwritten by specifying a name.

### DIFF
--- a/src/auth.provider.js
+++ b/src/auth.provider.js
@@ -209,7 +209,7 @@
       // Config can be passed as only a string, in which case it should be
       // set as the name of the `NarrativeAuth`.
       config = isString(config) ? {name: config} : (config || {});
-      this._config = extend(defaults, config);
+      this._config = extend({}, defaults, config);
 
       // This is the initial promise that is
       defer = this.$q.defer();

--- a/test/auth.provider.spec.js
+++ b/test/auth.provider.spec.js
@@ -57,6 +57,24 @@
       expect(auth.config().name).toEqual(name);
     });
 
+    it('does not affect default when setting a name.', function () {
+      var auth,
+        defaultName = narrativeAuthProvider.defaults.name,
+        name = 'Authwl';
+
+      auth = narrativeAuth(name);
+      expect(auth.config().name).toEqual(name);
+
+      auth = narrativeAuth();
+      expect(auth.config().name).toEqual(defaultName);
+
+      auth = narrativeAuth({name: name});
+      expect(auth.config().name).toEqual(name);
+
+      auth = narrativeAuth();
+      expect(auth.config().name).toEqual(defaultName);
+    });
+
     describe('NarrativeAuth.oauth', function () {
       var authorize, redirectURI, clientID, clientSecret, auth;
 


### PR DESCRIPTION
Defaults was previously overwritten when using named `NarrativeAuth`:s, this is addressed in this PR.
