### PR TITLE
Request cache

### DIFF
--- a/src/request-handler.provider.js
+++ b/src/request-handler.provider.js
@@ -122,11 +122,19 @@
      * A method for making authorized requests with parameters to Narratives
      * API on Narratives Open Platform.
      *
-     * @param  {string} method      [description]
-     * @param  {string} url         [description]
-     * @param  {Object} parameters  [description]
-     * @param  {NarrativeAuth} auth [description]
-     * @return {promise}            [description]
+     * @param  {string} method The HTTP method to be used for the reqest.
+     * @param  {string} url The URL relative to the supplied full API URL.
+     * @param  {object=} parameters Optional URL parameters to add to the
+     *                              request.
+     * @param  {NarrativeAuth|object=} authOrConfig Either a NarrativeAuth
+     *                                              or a configuration object
+     *                                              for this particular request.
+     *                                              The configuraiton object
+     *                                              accepts the same attributes
+     *                                              as the default selection for
+     *                                              `NarrativeCacheProvider`s
+     *                                              `default` values.
+     * @return {promise} Returns the promise produced by the `$http` service.
      */
     this.$get = [
       '$http', 'NarrativeAuth', '$injector',
@@ -166,7 +174,7 @@
           cache: config.cache,
           url: fullPath(config.api, url)
         };
-        
+
         // Unauthorized requests may be allowed to some endpoints, so only add
         // headers if a valid session exists.
         if (config.auth.token()) {

--- a/src/request-handler.provider.js
+++ b/src/request-handler.provider.js
@@ -86,7 +86,7 @@
 
     /**
      * A builder that combines the URLs provided in the API path along with
-     * the passed URL to create a c
+     * the passed URL to create a combined URL to make a request to.
      * @param  {string} url The relative URL to append to the base path.
      * @return {string}     The combined URL.
      */

--- a/test/mocks.js
+++ b/test/mocks.js
@@ -11,9 +11,13 @@
     alwaysTrue  = function () { return true; },
     alwaysFalse = function () { return false; },
     Auth = {
+      _name: 'global',
       _token: {
         token_type: 'Bearer',
         access_token: ':bear_arms'
+      },
+      config: function () {
+        return {name: this._name};
       },
       unauth: alwaysTrue,
       getOauthToken: function(code, parameters) {

--- a/test/request-handler.provider.spec.js
+++ b/test/request-handler.provider.spec.js
@@ -53,7 +53,8 @@
         apiSuffix: "api/v75/"
       };
       path = "http://proxy/https://narrative.com/api/v75/";
-      narrativeRequest = narrativeRequestProvider.$get.pop()(_$http_);
+      narrativeRequest = narrativeRequestProvider.$get.pop()(
+        _$http_, _NarrativeAuthMock_);
     }));
 
     it('does not add headers to unauthorized requests.', function () {
@@ -67,7 +68,7 @@
           expect(headers.Authorization).not.toBeDefined();
           return { data: 'Curious George' };
         });
-      narrativeRequest('GET', 'monkeys/', auth);
+      narrativeRequest('GET', 'monkeys/', {}, auth);
       $httpBackend.flush();
     });
 
@@ -81,7 +82,7 @@
           return { data: "Dolly, Dolly, Dolly" };
       });
 
-      narrativeRequest('GET', 'sheep/', auth);
+      narrativeRequest('GET', 'sheep/', {}, auth);
       $httpBackend.flush();
     });
 

--- a/test/request-handler.provider.spec.js
+++ b/test/request-handler.provider.spec.js
@@ -44,7 +44,7 @@
     beforeEach(module('api.narrative.mocks'));
 
     beforeEach(inject(function (_$httpBackend_,  _NarrativeAuthMock_,
-                                _$http_) {
+                                _$http_, _$injector_) {
       $httpBackend = _$httpBackend_;
       newAuth = _NarrativeAuthMock_;
       narrativeRequestProvider.defaults.api = {
@@ -54,7 +54,7 @@
       };
       path = "http://proxy/https://narrative.com/api/v75/";
       narrativeRequest = narrativeRequestProvider.$get.pop()(
-        _$http_, _NarrativeAuthMock_);
+        _$http_, _NarrativeAuthMock_, _$injector_);
     }));
 
     it('adds a new Auth if none is supplied.', function () {

--- a/test/request-handler.provider.spec.js
+++ b/test/request-handler.provider.spec.js
@@ -57,6 +57,18 @@
         _$http_, _NarrativeAuthMock_);
     }));
 
+    it('adds a new Auth if none is supplied.', function () {
+      var headerSpy = jasmine.createSpy('headerSpy');
+
+      $httpBackend.expectGET(path + 'monkeys/')
+        .respond(function (method, url, data, headers) {
+          expect(headers.Authorization).toBeDefined();
+          return { data: 'Curious George' };
+        });
+      narrativeRequest('GET', 'monkeys/');
+      $httpBackend.flush();
+    });
+
     it('does not add headers to unauthorized requests.', function () {
       var headerSpy = jasmine.createSpy('headerSpy'),
         auth = newAuth({


### PR DESCRIPTION
A per-auth-name caching is now available in the `requestHandler`.
