### PR TITLE
Added backslashes to the end of all urls required.

### DIFF
--- a/src/api.provider.js
+++ b/src/api.provider.js
@@ -99,9 +99,9 @@
         function momentTransform(moment) {
           return angular.extend(moment, {
             positions: constructArray(
-              arrayFactory, moment.path() + '/positions/', config.auth, [], []),
+              arrayFactory, moment.path() + 'positions/', config.auth, [], []),
             photos: constructArray(
-              arrayFactory, moment.path() + '/photos/', config.auth, [], [])
+              arrayFactory, moment.path() + 'photos/', config.auth, [], [])
           });
         }
 
@@ -138,7 +138,7 @@
          *                             the moment.
          */
         api.moment = constructItem(
-          itemFactory, 'moments/:uuid', config.auth, [momentTransform]);
+          itemFactory, 'moments/:uuid/', config.auth, [momentTransform]);
 
         /**
          * @ngdoc method
@@ -190,7 +190,7 @@
          *                             the user.
          */
         api.user = constructItem(
-          itemFactory, 'users/:uuid', config.auth, []);
+          itemFactory, 'users/:uuid/', config.auth, []);
 
         /**
          * @ngdoc method

--- a/src/resource.service.js
+++ b/src/resource.service.js
@@ -402,7 +402,7 @@
         resource._count = page.count;
 
         page.results = page.results.map(function (item) {
-          var obj = new NrtvItemResource(resource.path() + ':uuid',
+          var obj = new NrtvItemResource(resource.path() + ':uuid/',
                                          resource._auth, {}, resource._request,
                                          resource._$q);
 


### PR DESCRIPTION
Fixes for enabling valid preflight requests with HTTPS and CORS, that are not allowed to be redirected because of a slight URL mismatch, as was the case when using a proxy.
